### PR TITLE
fix(rules): remove deprecated NewInInitializerRector

### DIFF
--- a/build/ignored-rules.php
+++ b/build/ignored-rules.php
@@ -195,6 +195,7 @@ use Rector\Php81\Rector\Array_\ArrayToFirstClassCallableRector;
 use Rector\Php81\Rector\Array_\FirstClassCallableRector;
 use Rector\Php81\Rector\Class_\MyCLabsClassToEnumRector;
 use Rector\Php81\Rector\Class_\SpatieEnumClassToEnumRector;
+use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\MethodCall\MyCLabsMethodCallToEnumConstRector;
 use Rector\Php81\Rector\MethodCall\RemoveReflectionSetAccessibleCallsRector;
@@ -608,4 +609,5 @@ const IGNORED_RULES = [
     ConstAndTraitDeprecatedAttributeRector::class,
     SafeDeclareStrictTypesRector::class,
     CoalesceToTernaryRector::class,
+    NewInInitializerRector::class,
 ];

--- a/rules/rules.php
+++ b/rules/rules.php
@@ -114,7 +114,6 @@ use Rector\Php80\Rector\Identical\StrEndsWithRector;
 use Rector\Php80\Rector\Identical\StrStartsWithRector;
 use Rector\Php80\Rector\NotIdentical\StrContainsRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
-use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictIntPregSlitFuncCallLimitArgRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
 use Rector\Php82\Rector\Class_\ReadOnlyClassRector;
@@ -297,7 +296,6 @@ return [
     TypedPropertyFromStrictConstructorRector::class,
     ReadOnlyPropertyRector::class,
     SwitchTrueToIfRector::class,
-    NewInInitializerRector::class,
     IfIssetToCoalescingRector::class,
     CleanupUnneededNullsafeOperatorRector::class,
     ReadOnlyClassRector::class,


### PR DESCRIPTION
## Summary
- Move `NewInInitializerRector` from `rules.php` to `ignored-rules.php` as it is deprecated and produces a warning during `composer build`

## Test plan
- [x] `composer build` passes without deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)