### PR TITLE
chore: add .claude and CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /.phpunit.result.cache
 composer.lock
 /.cursor
+/.claude
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Adds `/.claude` directory and `CLAUDE.md` to `.gitignore` to keep Claude Code config files out of the repository

## Test plan
- [x] Verify untracked files no longer appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)