### PR TITLE
fix(ci): consolidate PR checks into single worker

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Package Checkers
+name: PR Checks
 
 on:
   pull_request:
@@ -6,19 +6,8 @@ on:
 
 jobs:
   checks:
-    name: Run Checks
+    name: Run All Checks
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        check:
-          - name: Missing Rules
-            command: composer check:missing-rules
-          - name: PHPCS
-            command: composer phpcs
-          - name: Rector
-            command: composer rector
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -44,11 +33,17 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
-
-      - name: Run ${{ matrix.check.name }}
-        id: check
-        continue-on-error: true
-        run: |
-          ${{ matrix.check.command }}
         env:
           COMPOSER_MEMORY_LIMIT: -1
+
+      - name: Run Missing Rules Check
+        run: composer check:missing-rules
+
+      - name: Run PHPCS
+        run: composer phpcs
+
+      - name: Run Rector
+        run: composer rector
+
+      - name: Run Security Audit
+        run: composer audit --format=table

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,6 @@ name: Security Audit
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
   schedule:
     - cron: '0 0 * * 1' # Every Monday at midnight
 


### PR DESCRIPTION
## Summary
- Merged all PR checkers (Missing Rules, PHPCS, Rector, Security Audit) into a single job in `pr.yml` — runs sequentially on one worker instead of 3+1 separate workers
- Removed `pull_request` trigger from `security.yml` (keeps `push` to master and weekly schedule)
- Reduces PR workflow from **5 workers** to **2 workers** (1 checks + 1 labels)
- **Behavioral change:** checks now properly block PRs on failure (previously `continue-on-error: true` silently swallowed failures)

Closes #37

## Test plan
- [ ] Open a test PR and verify all 4 checks run in the single "Run All Checks" job
- [ ] Verify `security.yml` still runs on push to master and on schedule
- [ ] Verify PR labels workflow still works independently
- [ ] Verify that a failing check correctly blocks the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)