### PR TITLE
chore: bump rector to ^2.4.4 and register AddNameToBooleanArgumentRector

### DIFF
--- a/build/find-missing-rules.php
+++ b/build/find-missing-rules.php
@@ -135,12 +135,12 @@ function findMissingRules(array $allRules, array $definedRules): array
     
     foreach ($allRules as $ruleClass) {
         // Check if rule is defined in rules.php
-        if (in_array($ruleClass, $definedRules, true)) {
+        if (in_array($ruleClass, $definedRules, strict: true)) {
             continue;
         }
         
         // Check if rule is ignored (compare with full class name)
-        if (in_array($ruleClass, IGNORED_RULES, true)) {
+        if (in_array($ruleClass, IGNORED_RULES, strict: true)) {
             continue;
         }
         

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   ],
   "require": {
     "php": "^8.4",
-    "rector/rector": "^2.4.2"
+    "rector/rector": "^2.4.4"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/rules/rules.php
+++ b/rules/rules.php
@@ -6,6 +6,7 @@ use Rector\CodeQuality\Rector\Assign\CombinedAssignRector;
 use Rector\CodeQuality\Rector\Attribute\SortAttributeNamedArgsRector;
 use Rector\CodeQuality\Rector\BooleanAnd\RepeatedAndNotEqualToNotInArrayRector;
 use Rector\CodeQuality\Rector\BooleanOr\RepeatedOrEqualToInArrayRector;
+use Rector\CodeQuality\Rector\CallLike\AddNameToBooleanArgumentRector;
 use Rector\CodeQuality\Rector\Catch_\ThrowWithPreviousExceptionRector;
 use Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector;
 use Rector\CodeQuality\Rector\Class_\ConvertStaticToSelfRector;
@@ -403,6 +404,7 @@ return [
     TypedStaticPropertyInBehatContextRector::class,
     SortAttributeNamedArgsRector::class,
     SortCallLikeNamedArgsRector::class,
+    AddNameToBooleanArgumentRector::class,
     RemoveParentDelegatingConstructorRector::class,
     NarrowWideUnionReturnTypeRector::class,
     RemoveNextSameValueConditionRector::class,


### PR DESCRIPTION
## Summary
- Bumped `rector/rector` constraint to `^2.4.4`
- Registered the new `AddNameToBooleanArgumentRector` rule in `rules/rules.php`
- Applied the rule to `build/find-missing-rules.php` (named `strict:` argument in `in_array` calls)

## Test plan
- [x] `composer update`
- [x] `composer bump`
- [x] `composer build` (phpcs + rector --dry-run + missing-rules check + cursor-rules install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)