### PR TITLE
chore(composer): replace pekral/cursor-rules with agentic-vibes/laravel-agent-skills

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-/.cursor export-ignore
+/.claude export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@
 .phpunit.result.cache
 /.phpunit.result.cache
 composer.lock
-/.cursor
 /.claude
 CLAUDE.md

--- a/composer.json
+++ b/composer.json
@@ -38,9 +38,15 @@
   "require-dev": {
     "roave/security-advisories": "dev-master",
     "pekral/phpcs-rules": "dev-master",
-    "pekral/cursor-rules": "dev-master",
+    "agentic-vibes/laravel-agent-skills": "dev-master",
     "pekral/phpstan-rules": "dev-master"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/agentic-vibes/laravel-agent-skills"
+    }
+  ],
   "autoload": {
     "psr-4": {
       "PekralRectorRule\\": "rules/"
@@ -52,7 +58,7 @@
     }
   },
   "scripts": {
-    "build": "composer check fix && composer check && composer cursor-rules:install",
+    "build": "composer check fix && composer check && composer agent-skills:install",
     "phpcs:fix": "vendor/bin/phpcbf --standard=vendor/pekral/phpcs-rules/ruleset.xml --standard=vendor/pekral/phpcs-rules rules/ build/ rector.php || true",
     "phpcs": "vendor/bin/phpcs --standard=vendor/pekral/phpcs-rules rules/ build/ rector.php -sp",
     "check": "composer phpcs && composer rector && composer check:missing-rules",
@@ -60,14 +66,14 @@
     "rector:fix": "vendor/bin/rector process rules/ build/ rector.php ",
     "fix": "composer rector:fix && composer phpcs:fix",
     "check:missing-rules": "php build/find-missing-rules.php",
-    "cursor-rules:install": "vendor/bin/cursor-rules install --force --editor=claude"
+    "agent-skills:install": "vendor/bin/agent-skills install --force"
   },
   "config": {
     "prefer-stable": true,
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,
       "phpstan/extension-installer": true,
-      "pekral/cursor-rules": true
+      "agentic-vibes/laravel-agent-skills": true
     }
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
## Co se mění

Nahrazuje `pekral/cursor-rules` balíčkem `agentic-vibes/laravel-agent-skills`, který přebírá instalaci rules, skills a agentů pro Claude Code.

- `require-dev`: `pekral/cursor-rules` → `agentic-vibes/laravel-agent-skills` (`dev-master`)
- `allow-plugins`: přejmenován klíč pluginu
- script `cursor-rules:install` → `agent-skills:install` (`vendor/bin/agent-skills install --force`) — nový installer je Claude-only, `--editor` flag už neexistuje
- `build` volá nový install script
- přidán `repositories` blok s VCS na GitHub (balíček zatím není na Packagist)
- `/.cursor` → `/.claude` v `.gitignore` a `.gitattributes` (do `.cursor` se už nic neinstaluje)

## Ověření

- `composer validate --strict` — OK
- `composer check` (phpcs + rector + check:missing-rules) — OK
- `composer agent-skills:install` — 251 souborů: 21 rules, 49 skills, 6 agentů

## Pozor: CI

`agentic-vibes/laravel-agent-skills` je zatím **private** a není na Packagist, takže `composer install` v `pr.yml`, `security.yml` a `composer-update.yml` selže na chybějícím přístupu. Po zveřejnění balíčku na Packagist lze `repositories` blok odstranit a CI se spraví samo; do té doby je potřeba do workflow přidat PAT.

Vypuštěné skills a agent `metis` oproti `cursor-rules` jsou záměr — aktuální logika žije v novém balíčku.