### PR TITLE
chore(rector): adapt rule set to rector 2.6.0

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, json, mbstring, pdo
           coverage: none
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,3 +47,32 @@ jobs:
 
       - name: Run Security Audit
         run: composer audit --format=table
+
+  min-php:
+    name: Lint on Declared Minimum PHP
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --strict --no-check-all
+
+      # composer --no-dev still resolves require-dev, and pekral/phpcs-rules
+      # requires PHP 8.5. Resolve a dev-free manifest instead, so this step
+      # verifies exactly what a consumer on the declared minimum installs.
+      - name: Verify runtime dependencies resolve
+        run: |
+          php -r '$c = json_decode(file_get_contents("composer.json"), true); unset($c["require-dev"], $c["scripts"], $c["autoload-dev"]); file_put_contents("composer.runtime.json", json_encode($c, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));'
+          COMPOSER=composer.runtime.json composer update --no-progress --prefer-dist --dry-run
+        env:
+          COMPOSER_MEMORY_LIMIT: -1
+
+      - name: Lint shipped sources
+        run: php -l rules/rules.php

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, json, mbstring, pdo
           coverage: none
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, json, mbstring, pdo
 
       - name: Get Composer Cache Directory

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ return static function (RectorConfig $rectorConfig): void {
 ## ⚙️ Configuration
 
 * Rules can be extended and customized in your `rector.php` configuration.
-* Supports PHP 8.4+.
+* Supports PHP 8.4+. Contributing to this repository requires PHP 8.5+, because the development dependencies do.
 * Easy integration with CI/CD (GitHub Actions, GitLab CI, ...).
 * Includes comprehensive examples for each rule.
 

--- a/build/ignored-rules.php
+++ b/build/ignored-rules.php
@@ -31,6 +31,7 @@ use Rector\CodeQuality\Rector\FuncCall\InlineIsAInstanceOfRector;
 use Rector\CodeQuality\Rector\FuncCall\IsAWithStringWithThirdArgumentRector;
 use Rector\CodeQuality\Rector\FuncCall\SetTypeToCastRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyFuncGetArgsCountRector;
+use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyStrposLowerRector;
 use Rector\CodeQuality\Rector\FuncCall\SingleInArrayToCompareRector;
 use Rector\CodeQuality\Rector\Identical\BooleanNotIdenticalToNotIdenticalRector;
@@ -50,14 +51,17 @@ use Rector\CodeQuality\Rector\Ternary\NumberCompareToMaxFuncCallRector;
 use Rector\CodeQuality\Rector\Ternary\TernaryImplodeToImplodeRector;
 use Rector\CodingStyle\Rector\ArrowFunction\ArrowFunctionDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\ArrowFunction\StaticArrowFunctionRector;
+use Rector\CodingStyle\Rector\Assign\NestedTernaryToMatchRector;
 use Rector\CodingStyle\Rector\Assign\SplitDoubleAssignRector;
 use Rector\CodingStyle\Rector\Catch_\CatchExceptionNameMatchingTypeRector;
 use Rector\CodingStyle\Rector\ClassConst\RemoveFinalFromConstRector;
 use Rector\CodingStyle\Rector\ClassConst\SplitGroupedClassConstantsRector;
+use Rector\CodingStyle\Rector\ClassMethod\BinaryOpStandaloneAssignsToDirectRector;
 use Rector\CodingStyle\Rector\ClassMethod\FuncGetArgsToVariadicParamRector;
 use Rector\CodingStyle\Rector\ClassMethod\NewlineBeforeNewAssignSetRector;
 use Rector\CodingStyle\Rector\Closure\ClosureDelegatingCallToFirstClassCallableRector;
 use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
+use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
 use Rector\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncArrayToVariadicRector;
@@ -287,6 +291,9 @@ use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 use Rector\TypeDeclaration\Rector\While_\WhileNullableToInstanceofRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\AddReturnArrayDocblockFromDataProviderParamRector;
+use Rector\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector;
+use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDataProviderRector;
+use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockFromMethodCallDocblockRector;
 use Rector\TypeDeclarationDocblocks\Rector\Property\MergePhpstanDocTagIntoNativeRector;
 use Rector\Unambiguous\Rector\Class_\RemoveReturnThisFromSetterClassMethodRector;
 use Rector\Visibility\Rector\ClassConst\ChangeConstantVisibilityRector;
@@ -593,4 +600,12 @@ const IGNORED_RULES = [
     TypedPropertyFromContainerGetSetUpRector::class,
     TypedPropertyFromGetRepositorySetUpRector::class,
     ReturnTypeFromGetRepositoryDocblockRector::class,
+    // Deprecated in rector/rector
+    SimplifyRegexPatternRector::class,
+    NestedTernaryToMatchRector::class,
+    BinaryOpStandaloneAssignsToDirectRector::class,
+    EncapsedStringsToSprintfRector::class,
+    AddReturnDocblockDataProviderRector::class,
+    AddParamArrayDocblockFromDataProviderRector::class,
+    AddReturnDocblockFromMethodCallDocblockRector::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   ],
   "require": {
     "php": "^8.4",
-    "rector/rector": "^2.5.8"
+    "rector/rector": "^2.6.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/rules/rules.php
+++ b/rules/rules.php
@@ -34,7 +34,6 @@ use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
 use Rector\CodeQuality\Rector\FuncCall\RemoveSoleValueSprintfRector;
 use Rector\CodeQuality\Rector\FuncCall\SimplifyInArrayValuesRector;
-use Rector\CodeQuality\Rector\FuncCall\SimplifyRegexPatternRector;
 use Rector\CodeQuality\Rector\FuncCall\SortCallLikeNamedArgsRector;
 use Rector\CodeQuality\Rector\FuncCall\UnwrapSprintfOneArgumentRector;
 use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
@@ -59,11 +58,8 @@ use Rector\CodeQuality\Rector\Ternary\SimplifyTautologyTernaryRector;
 use Rector\CodeQuality\Rector\Ternary\SwitchNegatedTernaryRector;
 use Rector\CodeQuality\Rector\Ternary\TernaryEmptyArrayArrayDimFetchToCoalesceRector;
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
-use Rector\CodingStyle\Rector\Assign\NestedTernaryToMatchRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
-use Rector\CodingStyle\Rector\ClassMethod\BinaryOpStandaloneAssignsToDirectRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
-use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\CodingStyle\Rector\FuncCall\StrictInArrayRector;
@@ -79,6 +75,7 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveMixedDocblockOverruledByNativeTypeR
 use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingClassMethodRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveParentDelegatingConstructorRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveReturnTagIncompatibleWithNativeTypeRector;
+use Rector\DeadCode\Rector\ClassMethod\RemoveTestsOverriddenPrivateMethodParameterRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedConstructorParamRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodParameterRector;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPrivateMethodRector;
@@ -224,7 +221,6 @@ use Rector\TypeDeclaration\Rector\FunctionLike\AddReturnTypeDeclarationFromYield
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictSetUpRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\AddParamTypeToRefactorMethodRector;
-use Rector\TypeDeclarationDocblocks\Rector\Class_\AddReturnDocblockDataProviderRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\AddVarArrayDocblockFromDimFetchAssignRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\ClassMethodArrayDocblockParamFromLocalCallsRector;
 use Rector\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromGetterReturnRector;
@@ -232,13 +228,11 @@ use Rector\TypeDeclarationDocblocks\Rector\Class_\DocblockVarArrayFromPropertyDe
 use Rector\TypeDeclarationDocblocks\Rector\Class_\DocblockVarFromParamDocblockInConstructorRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockBasedOnArrayMapRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromAssignsParamToParamReferenceRector;
-use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDataProviderRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddParamArrayDocblockFromDimFetchAccessRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForArrayDimAssignedObjectRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForCommonObjectDenominatorRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForDimFetchArrayFromAssignsRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockForJsonArrayRector;
-use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\AddReturnDocblockFromMethodCallDocblockRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockGetterReturnArrayFromPropertyDocblockVarRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\DocblockReturnArrayFromDirectArrayInstanceRector;
 use Rector\TypeDeclarationDocblocks\Rector\ClassMethod\NarrowArrayCollectionUnionReturnDocblockRector;
@@ -249,13 +243,11 @@ return [
     KnownMagicClassMethodTypeRector::class,
     AddParamStringTypeFromSprintfUseRector::class,
     AddParamFromDimFetchKeyUseRector::class,
-    BinaryOpStandaloneAssignsToDirectRector::class,
     ShellExecFunctionCallOverBackticksRector::class,
     RemoveUnusedClosureVariableUseRector::class,
     VariableConstFetchToClassConstFetchRector::class,
     RepeatedOrEqualToInArrayRector::class,
     DocblockReturnArrayFromDirectArrayInstanceRector::class,
-    AddParamArrayDocblockFromDataProviderRector::class,
     AddReturnDocblockForArrayDimAssignedObjectRector::class,
     DocblockGetterReturnArrayFromPropertyDocblockVarRector::class,
     AddParamArrayDocblockFromDimFetchAccessRector::class,
@@ -287,7 +279,6 @@ return [
     SimplifyIfReturnBoolRector::class,
     SimplifyTautologyTernaryRector::class,
     SimplifyInArrayValuesRector::class,
-    SimplifyRegexPatternRector::class,
     SimplifyUselessVariableRector::class,
     ThrowWithPreviousExceptionRector::class,
     UnnecessaryTernaryExpressionRector::class,
@@ -340,7 +331,6 @@ return [
     TernaryEmptyArrayArrayDimFetchToCoalesceRector::class,
     TernaryFalseExpressionToIfRector::class,
     MakeInheritedMethodVisibilitySameAsParentRector::class,
-    EncapsedStringsToSprintfRector::class,
     RecastingRemovalRector::class,
     RemoveDeadReturnRector::class,
     RemoveDeadTryCatchRector::class,
@@ -422,7 +412,6 @@ return [
     AssertIssetToSpecificMethodRector::class,
     AssertNotOperatorRector::class,
     AssertSameBoolNullToSpecificMethodRector::class,
-    AddReturnDocblockDataProviderRector::class,
     ReturnIteratorInDataProviderRector::class,
     RepeatedAndNotEqualToNotInArrayRector::class,
     DirnameDirConcatStringToDirectStringPathRector::class,
@@ -436,7 +425,6 @@ return [
     RemoveNextSameValueConditionRector::class,
     FluentSettersToStandaloneCallMethodRector::class,
     PrivatizeFinalClassConstantRector::class,
-    NestedTernaryToMatchRector::class,
     NewlineBetweenClassLikeStmtsRector::class,
     NarrowObjectReturnTypeRector::class,
     RemoveNullArgOnNullDefaultParamRector::class,
@@ -459,7 +447,6 @@ return [
     RemoveUnusedPrivatePropertyRector::class,
     RemoveDeadIfBlockRector::class,
     RemoveVoidDocblockFromMagicMethodRector::class,
-    AddReturnDocblockFromMethodCallDocblockRector::class,
     AddReturnDocblockForDimFetchArrayFromAssignsRector::class,
     AddVarArrayDocblockFromDimFetchAssignRector::class,
     RemoveUselessTernaryRector::class,
@@ -496,4 +483,5 @@ return [
     RemoveDefaultValueFromAssignedPropertyRector::class,
     RemoveDoubleSelfAssignRector::class,
 
+    RemoveTestsOverriddenPrivateMethodParameterRector::class,
 ];

--- a/rules/rules.php
+++ b/rules/rules.php
@@ -482,6 +482,5 @@ return [
     RemoveDeadInstanceOfAssertRector::class,
     RemoveDefaultValueFromAssignedPropertyRector::class,
     RemoveDoubleSelfAssignRector::class,
-
     RemoveTestsOverriddenPrivateMethodParameterRector::class,
 ];


### PR DESCRIPTION
## Proč

Bump `rector/rector` na `^2.6.0` rozbil `composer build` — 7 pravidel v `rules/rules.php` je v této verzi označeno jako deprecated a Rector na nich shodí zpracování souboru (`[ERROR] Could not process ...`). Zároveň verze 2.6.0 přinesla jedno nové pravidlo, které `check:missing-rules` hlásil jako chybějící.

## Co se změnilo

**1. Bump závislosti**
- `rector/rector`: `^2.5.8` → `^2.6.0`

**2. Přesun 7 deprecated pravidel z `rules/rules.php` do `build/ignored-rules.php`**

Odpovídá zavedené konvenci repa — ostatní deprecated pravidla (`SwitchTrueToIfRector`, `StaticClosureRector`, `JoinStringConcatRector`, …) už v ignore listu jsou.

| Pravidlo | Důvod deprecace (z `@deprecated` v Rectoru) |
| --- | --- |
| `SimplifyRegexPatternRector` | zkracování rozsahů (`[a-zA-Z0-9_]` → `\w`) je věc osobní preference, může zhoršit čitelnost |
| `NestedTernaryToMatchRector` | `match(true)` s vnořenými podmínkami bývá méně čitelný než původní ternary |
| `BinaryOpStandaloneAssignsToDirectRector` | míří na velmi specifický tvar 3 příkazů, účel je nejasný |
| `EncapsedStringsToSprintfRector` | převod interpolace na `sprintf()` je věc osobní preference |
| `AddReturnDocblockDataProviderRector` | typování docblocku data providerů nesouvisí s kvalitou kódu |
| `AddParamArrayDocblockFromDataProviderRector` | totéž |
| `AddReturnDocblockFromMethodCallDocblockRector` | kopíruje docblock z jiného volání — může být nesprávný a šíří chybu dál |

**Náhrada neexistuje ani u jednoho.** Ověřeno proti `@deprecated` anotacím ve zdrojích (`vendor/rector/rector/rules/`) — žádná z nich neuvádí náhradní pravidlo. Všech 7 je deprecated jako "matter of personal preference" nebo "not relevant to code quality", nikoli nahrazeno novějším pravidlem. Katalog: https://getrector.com/find-rule

**3. Zapnuto nové pravidlo z 2.6.0**
- `Rector\DeadCode\Rector\ClassMethod\RemoveTestsOverriddenPrivateMethodParameterRector` — odstraňuje parametr privátní testovací metody, který je před prvním použitím přepsán přímým přiřazením

## Testování

`composer build` prochází zeleně (phpcs + rector dry-run + `check:missing-rules` + cursor-rules install):

```
[OK] Rector is done!
Found 508 Rector rules.
Found 243 defined rules.
✅ All available Rector rules are already defined in rules/rules.php
```

Existující testy (4) procházejí, změna je konfigurační — **nové testy: no**.

## Zdroje

- https://getrector.com/find-rule — oficiální katalog pravidel Rectoru
- `@deprecated` anotace v `vendor/rector/rector/rules/` (autoritativní zdroj důvodů deprecace)

---

## Druhý commit: `ci(workflows): bump php to 8.5`

Bez něj tenhle PR neprojde CI. `pekral/phpcs-rules dev-master` mezitím zvedla požadavek na PHP `^8.5`, ale workflows běžely na `8.4`, takže `composer install` spadl ještě před spuštěním jakéhokoli checku:

```
pekral/phpcs-rules dev-master requires php ^8.5
-> your php version (8.4.24) does not satisfy that requirement
```

Šlo o preexistující problém, který blokoval **každý** PR na tomto repu, ne jen tenhle. `php-version: '8.4'` → `'8.5'` ve `pr.yml`, `composer-update.yml` a `security.yml`.

Původně jsem to zkusil jako samostatný PR #54, ale ten samostatně zelené CI mít nemohl — master ještě neobsahuje adaptaci na Rector 2.6.0, takže `check:missing-rules` padal. Obě změny musí přijít společně, #54 je zavřený.

**Trade-off:** `composer.json` deklaruje `"php": "^8.4"`, takže CI teď netestuje deklarovanou minimální verzi. Testovat na 8.4 ale nejde, dokud to dev toolchain nedovolí. Čistší varianty do budoucna (obě mimo rozsah tohoto PR): matrix `[8.4, 8.5]` s dev závislostmi jen na 8.5, nebo zvednutí `require.php` na `^8.5` (breaking change pro konzumenty).
