### PR TITLE
ci(workflows): bump php to 8.5

### DIFF
--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, json, mbstring, pdo
           coverage: none
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, json, mbstring, pdo
           coverage: none
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, dom, filter, gd, json, mbstring, pdo
 
       - name: Get Composer Cache Directory


### PR DESCRIPTION
## Proč

CI na tomto repu je momentálně **rozbité pro každý PR** — `composer install` spadne ještě před spuštěním jakéhokoli checku:

```
Problem 1
  - Root composer.json requires pekral/phpcs-rules dev-master
  - pekral/phpcs-rules dev-master requires php ^8.5
    -> your php version (8.4.24) does not satisfy that requirement
```

Dev závislost `pekral/phpcs-rules dev-master` mezitím zvedla požadavek na PHP `^8.5`, ale workflows běží na `8.4`. Lokálně problém není vidět, pokud má vývojář nainstalované PHP 8.5.

## Co se změnilo

`php-version: '8.4'` → `'8.5'` ve všech třech workflows:

- `.github/workflows/pr.yml`
- `.github/workflows/composer-update.yml`
- `.github/workflows/security.yml`

## Trade-off, který stojí za zvážení

`composer.json` deklaruje `"php": "^8.4"`, takže po tomhle merge **CI netestuje deklarovanou minimální verzi**. Testovat na 8.4 ale nejde — dev toolchain to nedovolí.

Dvě čistší varianty do budoucna, obě mimo rozsah tohoto PR:

1. Přidat do workflows matrix `[8.4, 8.5]` a dev závislosti instalovat jen na 8.5 (checky by na 8.4 běžely v omezeném režimu).
2. Zvednout `require.php` na `^8.5` — breaking change pro konzumenty balíčku.

Tenhle PR jen odblokovává CI minimálním zásahem.

## Testování

Změna je čistě konfigurační, ověří ji samotný běh CI na tomto PR. Lokálně `composer build` prochází na PHP 8.5.9.

Nové testy: **no**.

## Souvislost

Odblokovává [#53](https://github.com/pekral/rector-rules/pull/53) (adaptace na Rector 2.6.0), který na téhle chybě padá — po merge je potřeba #53 rebasnout.
