### PR TITLE
chore(rector): adapt rule set to rector 2.6.1

### DIFF
--- a/build/ignored-rules.php
+++ b/build/ignored-rules.php
@@ -26,6 +26,7 @@ use Rector\CodeQuality\Rector\ClassMethod\OptionalParametersAfterRequiredRector;
 use Rector\CodeQuality\Rector\Concat\JoinStringConcatRector;
 use Rector\CodeQuality\Rector\Equal\UseIdenticalOverEqualWithSameTypeRector;
 use Rector\CodeQuality\Rector\For_\ForRepeatedCountToOwnVariableRector;
+use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
 use Rector\CodeQuality\Rector\FuncCall\CallUserFuncWithArrowFunctionToInlineRector;
 use Rector\CodeQuality\Rector\FuncCall\InlineIsAInstanceOfRector;
 use Rector\CodeQuality\Rector\FuncCall\IsAWithStringWithThirdArgumentRector;
@@ -64,6 +65,7 @@ use Rector\CodingStyle\Rector\Closure\StaticClosureRector;
 use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\CodingStyle\Rector\Encapsed\WrapEncapsedVariableInCurlyBracesRector;
 use Rector\CodingStyle\Rector\Enum_\EnumCaseToPascalCaseRector;
+use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncArrayToVariadicRector;
 use Rector\CodingStyle\Rector\FuncCall\CallUserFuncToMethodCallRector;
 use Rector\CodingStyle\Rector\FuncCall\ClosureFromCallableToFirstClassCallableRector;
@@ -608,4 +610,6 @@ const IGNORED_RULES = [
     AddReturnDocblockDataProviderRector::class,
     AddParamArrayDocblockFromDataProviderRector::class,
     AddReturnDocblockFromMethodCallDocblockRector::class,
+    UnusedForeachValueToArrayKeysRector::class,
+    ArraySpreadInsteadOfArrayMergeRector::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   ],
   "require": {
     "php": "^8.4",
-    "rector/rector": "^2.6.0"
+    "rector/rector": "^2.6.1"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",

--- a/rules/rules.php
+++ b/rules/rules.php
@@ -28,7 +28,6 @@ use Rector\CodeQuality\Rector\Expression\TernaryFalseExpressionToIfRector;
 use Rector\CodeQuality\Rector\Foreach_\ForeachItemsAssignToEmptyArrayToAssignRector;
 use Rector\CodeQuality\Rector\Foreach_\ForeachToInArrayRector;
 use Rector\CodeQuality\Rector\Foreach_\SimplifyForeachToCoalescingRector;
-use Rector\CodeQuality\Rector\Foreach_\UnusedForeachValueToArrayKeysRector;
 use Rector\CodeQuality\Rector\FuncCall\ArrayMergeOfNonArraysToSimpleArrayRector;
 use Rector\CodeQuality\Rector\FuncCall\ChangeArrayPushToArrayAssignRector;
 use Rector\CodeQuality\Rector\FuncCall\CompactToVariablesRector;
@@ -60,7 +59,6 @@ use Rector\CodeQuality\Rector\Ternary\TernaryEmptyArrayArrayDimFetchToCoalesceRe
 use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
 use Rector\CodingStyle\Rector\ClassLike\NewlineBetweenClassLikeStmtsRector;
 use Rector\CodingStyle\Rector\ClassMethod\MakeInheritedMethodVisibilitySameAsParentRector;
-use Rector\CodingStyle\Rector\FuncCall\ArraySpreadInsteadOfArrayMergeRector;
 use Rector\CodingStyle\Rector\FuncCall\ConsistentImplodeRector;
 use Rector\CodingStyle\Rector\FuncCall\StrictInArrayRector;
 use Rector\DeadCode\Rector\Assign\RemoveDoubleAssignRector;
@@ -282,7 +280,6 @@ return [
     SimplifyUselessVariableRector::class,
     ThrowWithPreviousExceptionRector::class,
     UnnecessaryTernaryExpressionRector::class,
-    UnusedForeachValueToArrayKeysRector::class,
     UnwrapSprintfOneArgumentRector::class,
     ReturnTypeFromStrictNewArrayRector::class,
     ReturnEarlyIfVariableRector::class,
@@ -406,7 +403,6 @@ return [
     AnnotationWithValueToAttributeRector::class,
     ArrayKeyFirstLastRector::class,
     ArrayMergeOfNonArraysToSimpleArrayRector::class,
-    ArraySpreadInsteadOfArrayMergeRector::class,
     AssertCompareOnCountableWithMethodToAssertCountRector::class,
     AssertEqualsToSameRector::class,
     AssertIssetToSpecificMethodRector::class,


### PR DESCRIPTION
Rector 2.6.1 hard-errors on a registered deprecated rule, so the two rules it newly deprecated break every consumer's `rector process` run — including `pekral/cursor-rules` CI, where the crash surfaced first (24× `Could not process ... System error` on files the PR never touched).

Same maintenance as 691bbfe (`adapt rule set to rector 2.6.0`):

- bump `rector/rector` to `^2.6.1`
- move `UnusedForeachValueToArrayKeysRector` and `ArraySpreadInsteadOfArrayMergeRector` from `rules/rules.php` to `build/ignored-rules.php`

Skipping the rules downstream via `->withSkip()` does not help — rector-core raises the error at rule **registration**, so the fix has to be here.

The set was cross-checked against every rule in `vendor/rector/rector/rules` that throws the deprecation `ShouldNotHappenException` (15 total); these two were the only ones still registered.

`composer check` green: phpcs clean, rector dry-run clean, 241 defined rules, all available rules still covered.