### PR TITLE
chore(dist): exclude development-only files from the distributed archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 /.cursor export-ignore
+/.github export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/build export-ignore


### PR DESCRIPTION
## Souhrn

Rozšiřuje `.gitattributes` o `export-ignore`, takže se do `vendor/` konzumenta dostane jen to, co balíček ke své funkci potřebuje.

Nově vyloučeno: `/.github`, `/build`, `/.gitignore`, `/.gitattributes` (`/.cursor` už tam bylo).

## Dopad na distribuci

Měřeno přes `git archive` — přesně to, co Composer stahuje jako dist:

| | Před | Po |
|---|---|---|
| Souborů | 14 | 4 |
| Velikost archivu | 120 kB | 40 kB |

Zůstává `composer.json`, `rector.php`, `rules/rules.php`, `README.md`.

Největší úspora je `build/ignored-rules.php` (34 kB) — vývojový seznam pro `composer check:missing-rules`, který konzument nikdy nespouští.

## Ověření

- Rozbalený archiv nainstalován do čistého projektu přes path repozitář a spuštěn `vendor/bin/rector process src --dry-run` → pravidla se načetla, `SimplifyUselessVariableRector` reálně zafungoval, žádné warningy.
- `composer build` v repu prochází — `export-ignore` platí jen pro `git archive`, ne pro checkout, takže vývojové skripty v `build/` fungují dál.
- `composer validate --strict` v pořádku.

## Poznámka pro případné konzumenty

Kdo by `vendor/pekral/rector-rules/build/ignored-rules.php` importoval ve svém `rector.php`, po této změně soubor nenajde. Není to dokumentovaný způsob použití (README ho nikde nezmiňuje) a jde o vývojový seznam, ne o veřejné API — ale stojí za zmínku v release notes.