### PR TITLE
chore(dist): drop dead export-ignore entry for /.cursor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
-/.cursor export-ignore
 /.github export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
## Souhrn

Odstraňuje `/​.cursor export-ignore` z `.gitattributes`. Ten řádek nikdy nic nedělal.

## Proč je mrtvý

`export-ignore` vylučuje soubory z `git archive`. Do archivu se ale dostane jen to, co je **verzované v gitu** — a `/.cursor` je v `.gitignore`, takže tam nikdy nebyl. Navíc adresář v repu vůbec neexistuje: `composer build` spouští `cursor-rules install --editor=claude`, což generuje `.claude/`, ne `.cursor/`.

Stejná úvaha platí i pro `/.claude` — proto ho tento PR nepřidává. Byl by to zase jen mrtvý řádek.

Zbývající čtyři položky funkční jsou: `/.github`, `/build`, `/.gitignore` a `/.gitattributes` **jsou** verzované, takže je `export-ignore` reálně z distribuce vyřazuje (viz #57).

## Ověření

Porovnal jsem obsah `git archive` před a po změně:

```
PŘED: README.md, composer.json, rector.php, rules/rules.php
PO:   README.md, composer.json, rector.php, rules/rules.php
```

Identické — což je přesně to, co tvrzení "mrtvý řádek" znamená. `composer build` prochází.

## Kontext

Vychází z konfliktu, na kterém uvázl zavřený #51 — ten chtěl řádek přepsat na `/.claude export-ignore`. Odstranění je čistší: konflikt tím zmizí a nevzniká další bezúčelný řádek.