### PR TITLE
chore(composer): require rector/rector ^2.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
   ],
   "require": {
     "php": "^8.4",
-    "rector/rector": "^2.6.1"
+    "rector/rector": "^2.6.2"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",


### PR DESCRIPTION
Raises the `rector/rector` floor to `^2.6.2`, the release whose deprecations the ruleset was aligned with in `2d3f08d` (`JsonThrowOnErrorRector` became a hard system error there, and `RemoveRedundantTypeCheckRector` was added).

Without the bump a consumer may resolve 2.6.1, where `RemoveRedundantTypeCheckRector` does not exist and the registered set fails to load.

Recovered from a local commit made while the ruleset fix was being prepared.